### PR TITLE
Removes multiDex

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,8 +14,6 @@ android {
         versionName = "1.3.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
-        vectorDrawables.useSupportLibrary = true
-        multiDexEnabled = true
     }
 
     signingConfigs {
@@ -54,7 +52,6 @@ dependencies {
     // Core
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.cardview:cardview:1.0.0")
-    implementation("androidx.multidex:multidex:2.0.1")
 
     // Media
     implementation("androidx.media3:media3-exoplayer:1.3.0")

--- a/app/src/main/java/com/meenbeese/chronos/Chronos.kt
+++ b/app/src/main/java/com/meenbeese/chronos/Chronos.kt
@@ -1,5 +1,6 @@
 package com.meenbeese.chronos
 
+import android.app.Application
 import android.content.Intent
 import android.graphics.Color
 import android.media.Ringtone
@@ -18,7 +19,6 @@ import androidx.media3.datasource.DefaultDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.exoplayer.hls.HlsMediaSource
 import androidx.media3.exoplayer.source.MediaSource
-import androidx.multidex.MultiDexApplication
 
 import com.afollestad.aesthetic.Aesthetic.Companion.get
 import com.afollestad.aesthetic.AutoSwitchMode
@@ -32,7 +32,7 @@ import com.meenbeese.chronos.services.TimerService
 import java.util.Calendar
 
 
-class Chronos : MultiDexApplication(), Player.Listener {
+class Chronos : Application(), Player.Listener {
     lateinit var alarms: ArrayList<AlarmData>
     lateinit var timers: ArrayList<TimerData>
     private var listeners: MutableList<ChronosListener>? = null


### PR DESCRIPTION
This PR :
- Removes `multiDexEnabled` property -> not necessary on Android 5 and upper https://developer.android.com/build/multidex
- Remove multiDex in main class and replace by `Application()` from Android app library
- Removes `vectorDrawables.useSupportLibrary` property -> not necessary on Android 5 and upper
