### PR TITLE
Remove cardview dependency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,6 @@ android {
 dependencies {
     // Core
     implementation("androidx.appcompat:appcompat:1.6.1")
-    implementation("androidx.cardview:cardview:1.0.0")
 
     // Media
     implementation("androidx.media3:media3-exoplayer:1.3.0")


### PR DESCRIPTION
CardView library is not used in the project.
And if we plan to use this, in the future he is present in Material library.