### PR TITLE
Enable non Transitive RClass parameter

### DIFF
--- a/app/src/main/java/com/meenbeese/chronos/activities/AlarmActivity.kt
+++ b/app/src/main/java/com/meenbeese/chronos/activities/AlarmActivity.kt
@@ -216,7 +216,7 @@ class AlarmActivity : AestheticActivity(), SlideActionListener {
         stopAnnoyance()
         AlertDialog.Builder(
             this@AlarmActivity,
-            if (isDark) R.style.Theme_AppCompat_Dialog_Alert else R.style.Theme_AppCompat_Light_Dialog_Alert
+            if (isDark) androidx.appcompat.R.style.Theme_AppCompat_Dialog_Alert else androidx.appcompat.R.style.Theme_AppCompat_Light_Dialog_Alert
         )
             .setItems(names) { _: DialogInterface?, which: Int ->
                 if (which < minutes.size) {

--- a/app/src/main/java/com/meenbeese/chronos/data/preference/ThemePreferenceData.kt
+++ b/app/src/main/java/com/meenbeese/chronos/data/preference/ThemePreferenceData.kt
@@ -42,7 +42,7 @@ class ThemePreferenceData : BasePreferenceData<ThemePreferenceData.ViewHolder>()
 
     @SuppressLint("CheckResult")
     override fun bindViewHolder(holder: ViewHolder) {
-        holder.themeSpinner.adapter = ArrayAdapter.createFromResource(holder.itemView.context, R.array.array_themes, R.layout.support_simple_spinner_dropdown_item)
+        holder.themeSpinner.adapter = ArrayAdapter.createFromResource(holder.itemView.context, R.array.array_themes, androidx.appcompat.R.layout.support_simple_spinner_dropdown_item)
 
         val theme : Int = holder.chronos?.activityTheme ?: Chronos.THEME_DAY_NIGHT
         run {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 # Project-wide Gradle settings.
 android.enableJetifier=true
 android.nonFinalResIds=false
-android.nonTransitiveRClass=false
+android.nonTransitiveRClass=true
 android.useAndroidX=true
 org.gradle.configuration-cache=true
 org.gradle.jvmargs=-Xmx4096m


### PR DESCRIPTION
Actually, when we call resources from libraries, sometimes we can take other resources in apk not necessary because we don't have give full path of resources.

With non-Transitive R Class, we are obliged to specify the full path of libraries resources, but we can reduce build time.