### PR TITLE
Fix warnings and deprecations

### DIFF
--- a/app/src/main/java/com/meenbeese/chronos/adapters/SoundsAdapter.kt
+++ b/app/src/main/java/com/meenbeese/chronos/adapters/SoundsAdapter.kt
@@ -131,12 +131,7 @@ class SoundsAdapter(private val chronos: Chronos, private val sounds: List<Sound
     }
 
     class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
-        val icon: ImageView
-        val title: TextView
-
-        init {
-            icon = itemView.findViewById(R.id.icon)
-            title = itemView.findViewById(R.id.title)
-        }
+        val icon: ImageView = itemView.findViewById(R.id.icon)
+        val title: TextView = itemView.findViewById(R.id.title)
     }
 }

--- a/app/src/main/java/com/meenbeese/chronos/adapters/TimeZonesAdapter.kt
+++ b/app/src/main/java/com/meenbeese/chronos/adapters/TimeZonesAdapter.kt
@@ -61,14 +61,8 @@ class TimeZonesAdapter(private val timeZones: List<String>) :
     }
 
     class ViewHolder(v: View) : RecyclerView.ViewHolder(v) {
-        val time: TextView
-        val title: TextView
-        val checkBox: MaterialCheckBox
-
-        init {
-            time = v.findViewById(R.id.time)
-            title = v.findViewById(R.id.title)
-            checkBox = v.findViewById(R.id.checkbox)
-        }
+        val time: TextView = v.findViewById(R.id.time)
+        val title: TextView = v.findViewById(R.id.title)
+        val checkBox: MaterialCheckBox = v.findViewById(R.id.checkbox)
     }
 }

--- a/app/src/main/java/com/meenbeese/chronos/data/preference/AlertWindowPreferenceData.kt
+++ b/app/src/main/java/com/meenbeese/chronos/data/preference/AlertWindowPreferenceData.kt
@@ -17,7 +17,6 @@ import androidx.core.widget.CompoundButtonCompat
 import com.afollestad.aesthetic.Aesthetic
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.switchmaterial.SwitchMaterial
-import com.meenbeese.chronos.Chronos
 import com.meenbeese.chronos.R
 
 

--- a/app/src/main/java/com/meenbeese/chronos/dialogs/TimerDialog.kt
+++ b/app/src/main/java/com/meenbeese/chronos/dialogs/TimerDialog.kt
@@ -33,10 +33,9 @@ class TimerDialog(context: Context, private val manager: FragmentManager) :
     private var time: TextView? = null
     private var backspace: ImageView? = null
     private var input = "000000"
-    private val chronos: Chronos
+    private val chronos: Chronos = context.applicationContext as Chronos
 
     init {
-        chronos = context.applicationContext as Chronos
         ringtone = SoundData.fromString(PreferenceData.DEFAULT_TIMER_RINGTONE.getValue(context, ""))
     }
 

--- a/app/src/main/java/com/meenbeese/chronos/fragments/HomeFragment.kt
+++ b/app/src/main/java/com/meenbeese/chronos/fragments/HomeFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewTreeObserver.OnGlobalLayoutListener
 import android.widget.ImageView
 
 import androidx.coordinatorlayout.widget.CoordinatorLayout
+import androidx.core.content.ContextCompat
 import androidx.viewpager.widget.ViewPager
 
 import io.reactivex.disposables.CompositeDisposable
@@ -99,7 +100,7 @@ class HomeFragment : BaseFragment() {
             SpeedDialActionItem
                 .Builder(R.id.alarm_fab, R.drawable.ic_alarm_add)
                 .setLabel(R.string.title_set_alarm)
-                .setLabelBackgroundColor(getFabLabelBgColor())
+                .setLabelBackgroundColor(getFabLabelBgColor(requireContext()))
                 .setLabelClickable(true)
                 .create()
         )
@@ -107,7 +108,7 @@ class HomeFragment : BaseFragment() {
             SpeedDialActionItem
                 .Builder(R.id.timer_fab, R.drawable.ic_timer)
                 .setLabel(R.string.title_set_timer)
-                .setLabelBackgroundColor(getFabLabelBgColor())
+                .setLabelBackgroundColor(getFabLabelBgColor(requireContext()))
                 .setLabelClickable(true)
                 .create()
         )
@@ -115,7 +116,7 @@ class HomeFragment : BaseFragment() {
             SpeedDialActionItem
                 .Builder(R.id.stopwatch_fab, R.drawable.ic_stopwatch)
                 .setLabel(R.string.title_set_stopwatch)
-                .setLabelBackgroundColor(getFabLabelBgColor())
+                .setLabelBackgroundColor(getFabLabelBgColor(requireContext()))
                 .setLabelClickable(true)
                 .create()
         )
@@ -257,11 +258,11 @@ class HomeFragment : BaseFragment() {
     /**
      * Helper extension function to manage the background colors of the FAB label.
      */
-    private fun getFabLabelBgColor(): Int {
+    private fun getFabLabelBgColor(context: Context): Int {
         return if (chronos!!.isDarkTheme()) {
-            resources.getColor(R.color.colorNightPrimary)
+            ContextCompat.getColor(context, R.color.colorNightPrimary)
         } else {
-            resources.getColor(R.color.colorPrimary)
+            ContextCompat.getColor(context, R.color.colorPrimary)
         }
     }
 

--- a/app/src/main/java/com/meenbeese/chronos/fragments/SettingsFragment.kt
+++ b/app/src/main/java/com/meenbeese/chronos/fragments/SettingsFragment.kt
@@ -7,7 +7,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 
-import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 


### PR DESCRIPTION
This PR fixes Android Studio warnings and deprecated methods:
- Declare and assign at the same time
- Removes unused import
- Fixes `resources.getColor deprecation` -> https://stackoverflow.com/questions/31842983/getresources-getcolor-is-deprecated